### PR TITLE
SS-81 API Создание теста SS-80 API Редактирование теста

### DIFF
--- a/api-tests/src/test/java/tests/managetests/CreateTestApiTests.java
+++ b/api-tests/src/test/java/tests/managetests/CreateTestApiTests.java
@@ -1,0 +1,145 @@
+package tests.managetests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+
+import java.util.Map;
+
+public class CreateTestApiTests extends BaseTest {
+
+    @Test
+    @DisplayName("Позитивный сценарий: успешное создание теста")
+    void createTestSuccessfully() {
+        String testName = "API Test " + System.currentTimeMillis();
+        String testDescription = "This is a test created via API";
+
+        Response response = ManageTests.createTest(cookie, testName, testDescription);
+
+        ManageTests.verifyCreateTest(response);
+    }
+
+    @Test
+    @DisplayName("Позитивный сценарий: создание теста без описания")
+    void createTestWithoutDescription() {
+        String testName = "API Test " + System.currentTimeMillis();
+
+        Response response = ManageTests.createTest(cookie, testName, "");
+        response.then().statusCode(201);
+    }
+
+    @Test
+    @DisplayName("Негативный сценарий: создание теста без имени")
+    void createTestWithoutName() {
+        String testDescription = "Test without name";
+
+        Response response = ManageTests.createTest(cookie, "", testDescription);
+
+        response.then().statusCode(400);
+    }
+
+
+    @Test
+    @DisplayName("Редактирование теста: изменение названия")
+    void updateTestName() throws JsonProcessingException {
+        Response createResponse = ManageTests.createTest(cookie, "Original Test", "Original Description");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(cookie, testId, Map.of(
+                "name", "Updated Test Name"
+        ));
+
+        ManageTests.verifyUpdateTest(updateResponse);
+    }
+
+    @Test
+    @DisplayName("Редактирование теста: изменение описания")
+    void updateTestDescription() throws JsonProcessingException {
+        Response createResponse = ManageTests.createTest(cookie, "Original Test", "Original Description");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(cookie, testId, Map.of(
+                "description", "Updated Description"
+        ));
+
+        ManageTests.verifyUpdateTest(updateResponse);
+    }
+
+    @Test
+    @DisplayName("Редактирование теста: изменение имени и описания")
+    void updateTestNameAndDescription() throws JsonProcessingException {
+        Response createResponse = ManageTests.createTest(cookie, "Original Test", "Original Description");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(cookie, testId, Map.of(
+                "name", "Updated Test Name",
+                "description", "Updated Description"
+        ));
+
+        ManageTests.verifyUpdateTest(updateResponse);
+    }
+
+    @Test
+    @DisplayName("Редактирование теста: изменение лимита времени")
+    void updateTestTimeLimit() throws JsonProcessingException {
+
+        Response createResponse = ManageTests.createTest(cookie, "Original Test", "Original Description");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(
+                cookie,
+                testId,
+                java.util.Map.of("timeLimit", 30)
+        );
+
+        ManageTests.verifyUpdateTest(updateResponse);
+
+        org.junit.jupiter.api.Assertions.assertEquals(30, updateResponse.jsonPath().getInt("timeLimit"),
+                "timeLimit должен обновиться до 30");
+    }
+
+    @Test
+    @DisplayName("Редактирование теста: изменение проходного балла")
+    void updateTestPassingScore() throws JsonProcessingException {
+
+        Response createResponse = ManageTests.createTest(cookie, "Original Test", "Original Description");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(
+                cookie,
+                testId,
+                java.util.Map.of("passingScore", 85)
+        );
+
+        ManageTests.verifyUpdateTest(updateResponse);
+
+        org.junit.jupiter.api.Assertions.assertEquals(
+                85,
+                updateResponse.jsonPath().getInt("passingScore"),
+                "passingScore должен обновиться до 85"
+        );
+    }
+
+    @Test
+    @DisplayName("Редактирование теста: изменение активности")
+    void updateTestIsActive() throws JsonProcessingException {
+
+        Response createResponse = ManageTests.createTest(cookie, "Inactive Test", "With flag");
+        String testId = createResponse.jsonPath().getString("id");
+
+        Response updateResponse = ManageTests.updateTest(
+                cookie,
+                testId,
+                java.util.Map.of("isActive", true)
+        );
+
+        ManageTests.verifyUpdateTest(updateResponse);
+
+        org.junit.jupiter.api.Assertions.assertTrue(
+                updateResponse.jsonPath().getBoolean("isActive"),
+                "Поле isActive должно быть true"
+        );
+    }
+}

--- a/api-tests/src/test/resources/schemas.manage/CreateTestSuccessResponse.json
+++ b/api-tests/src/test/resources/schemas.manage/CreateTestSuccessResponse.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Create Test Success Response",
+  "type": "object",
+  "properties": {
+    "id":          { "type": ["string", "integer"] },
+    "name":        { "type": "string", "minLength": 1 },
+    "description": { "type": "string" }
+  },
+  "required": ["id", "name"],
+  "additionalProperties": true
+}

--- a/api-tests/src/test/resources/schemas.manage/UpdateTestSuccessResponse.json
+++ b/api-tests/src/test/resources/schemas.manage/UpdateTestSuccessResponse.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Update Test Success Response",
+  "type": "object",
+  "properties": {
+    "id": { "type": "integer" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "createdBy": { "type": "integer" },
+    "timeLimit": { "type": ["integer", "null"] },
+    "isActive": { "type": "boolean" },
+    "passingScore": { "type": "integer" }
+  },
+  "required": ["id", "name", "description"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Добавляю первые автотесты для управления тестами (создание теста) + соответствующие JSON-схемы валидации ответов. Цель — заложить основу для полного покрытия раздела «Управление тестами» API-тестами с Allure.
Что сделано - Тест создания теста: позитивный и негативный сценарии. - Вынесена обёртка ManageTests для удобного вызова эндпоинтов. - Добавлены JSON-схемы для успешных ответов create и update.
Добавлены тесты на редактирование: - имени теста - описания - лимита времени - проходного балла - статуса активности (isActive)
  - Реализован метод `ManageTests.updateTest()` 
  - Добавлена JSON-схема для успешного ответа при обновлении теста.
  - Расширен `CreateTestApiTests` дополнительными сценариями редактирования.