### PR TITLE
SS-78 Api назначение теста кандидату

### DIFF
--- a/api-tests/src/test/java/tests/questiontests/QuestionsApiTests.java
+++ b/api-tests/src/test/java/tests/questiontests/QuestionsApiTests.java
@@ -1,0 +1,61 @@
+package tests.questiontests;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+
+public class QuestionsApiTests extends BaseTest {
+
+
+    @Test
+    @DisplayName("Создание вопроса: 201 + схема")
+    void createQuestion_success() throws com.fasterxml.jackson.core.JsonProcessingException {
+
+        io.restassured.response.Response createTestResp =
+                wrappers.ManageTests.createTest(cookie, "API Test", "for questions");
+        int testId = createTestResp.jsonPath().getInt("id");
+
+        java.util.Map<String, Object> body = new java.util.HashMap<>();
+        body.put("testId", testId);
+        body.put("content", "What is 2+2?");
+        body.put("type", "single_choice");
+        body.put("options", java.util.Map.of("A", "3", "B", "4", "C", "5"));
+        body.put("correctAnswer", java.util.Map.of("key", "B"));
+        body.put("points", 5);
+        body.put("order", 1);
+        body.put("imageUrl", null);
+        body.put("codeSnippet", null);
+        body.put("codeLanguage", "javascript");
+
+        io.restassured.response.Response resp = wrappers.Questions.createQuestion(cookie, body);
+
+        resp.then()
+                .statusCode(201)
+                .body(io.restassured.module.jsv.JsonSchemaValidator
+                        .matchesJsonSchemaInClasspath("schemas.questions/CreateQuestionSuccessResponse.json"));
+    }
+
+    @Test
+    @DisplayName("Создание вопроса: 400 если отсутствует testId")
+    void createQuestion_missingTestId_400() throws com.fasterxml.jackson.core.JsonProcessingException {
+        wrappers.ManageTests.createTest(cookie, "API Negative", "missing testId");
+
+        java.util.Map<String, Object> body = new java.util.HashMap<>();
+        body.put("content", "What is 2 + 2?");
+        body.put("type", "single_choice");
+        body.put("options", java.util.Map.of("A", "3", "B", "4", "C", "5"));
+        body.put("correctAnswer", java.util.Map.of("key", "B"));
+        body.put("points", 5);
+        body.put("order", 1);
+        body.put("imageUrl", null);
+        body.put("codeSnippet", null);
+        body.put("codeLanguage", "javascript");
+
+        io.restassured.response.Response resp = wrappers.Questions.createQuestion(cookie, body);
+
+        resp.then().statusCode(org.hamcrest.Matchers.anyOf(
+                org.hamcrest.Matchers.is(400),
+                org.hamcrest.Matchers.is(422)
+        ));
+    }
+}

--- a/api-tests/src/test/java/tests/sessiontests/SessionsApiTests.java
+++ b/api-tests/src/test/java/tests/sessiontests/SessionsApiTests.java
@@ -1,0 +1,60 @@
+package tests.sessiontests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import dto.candidates.CandidatesRequest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Candidates;
+import wrappers.ManageTests;
+import wrappers.Sessions;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.module.jsv.JsonSchemaValidator.matchesJsonSchemaInClasspath;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+
+public class SessionsApiTests extends BaseTest {
+
+    @Test
+    @DisplayName("Назначить тест кандидату: 201 + схема ответа")
+    void createSession_success() throws JsonProcessingException {
+
+        int testId = ManageTests.createTest(cookie, "API Session Test", "assign")
+                .jsonPath().getInt("id");
+
+
+        CandidatesRequest payload = new CandidatesRequest();
+        payload.setName("API Candidate");
+        payload.setEmail("api.candidate" + System.currentTimeMillis() + "@skillchecker.tech");
+        payload.setPhone("+380501234567");
+        payload.setPosition("QA Automation");
+
+        Response candidateResp = Candidates.createNewCandidate(cookie, payload);
+        int candidateId = candidateResp.jsonPath().getInt("id");
+
+
+        String expiresAt = Instant.now()
+                .plus(3, ChronoUnit.DAYS)
+                .truncatedTo(ChronoUnit.SECONDS)
+                .toString();
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("testId", testId);
+        body.put("candidateId", candidateId);
+        body.put("expiresAt", expiresAt);
+
+
+        Response resp = Sessions.createSession(cookie, body);
+
+
+        resp.then()
+                .statusCode(anyOf(is(201), is(200)))
+                .body(matchesJsonSchemaInClasspath("schemas/sessions/CreateSessionSuccessResponse.json"));
+    }
+}

--- a/api-tests/src/test/java/wrappers/Questions.java
+++ b/api-tests/src/test/java/wrappers/Questions.java
@@ -1,0 +1,29 @@
+package wrappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class Questions {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static Response createQuestion(String cookie, Map<String, Object> body) throws JsonProcessingException {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Cookie", cookie)
+                .body(objectMapper.writeValueAsString(body))
+                .when()
+                .post("questions")
+                .then()
+                .extract().response();
+    }
+
+
+}

--- a/api-tests/src/test/java/wrappers/Sessions.java
+++ b/api-tests/src/test/java/wrappers/Sessions.java
@@ -1,0 +1,27 @@
+package wrappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class Sessions {
+    private static final ObjectMapper om = new ObjectMapper();
+
+    public static Response createSession(String cookie, Map<String, Object> body) throws JsonProcessingException {
+        String json = om.writeValueAsString(body);
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Cookie", cookie)
+                .body(json)
+                .when()
+                .post("sessions")
+                .then()
+                .extract().response();
+    }
+}

--- a/api-tests/src/test/resources/schemas.questions/CreateQuestionSuccessResponse.json
+++ b/api-tests/src/test/resources/schemas.questions/CreateQuestionSuccessResponse.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "organizationId": {
+      "type": "integer"
+    },
+    "testId": {
+      "type": "integer"
+    },
+    "content": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string"
+    },
+    "options": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "correctAnswer": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "points": {
+      "type": "integer"
+    },
+    "order": {
+      "type": "integer"
+    },
+    "imageUrl": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "codeSnippet": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "codeLanguage": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "testId",
+    "content",
+    "type",
+    "options",
+    "correctAnswer",
+    "points",
+    "order",
+    "codeLanguage"
+  ]
+}

--- a/api-tests/src/test/resources/schemas/sessions/CreateSessionSuccessResponse.json
+++ b/api-tests/src/test/resources/schemas/sessions/CreateSessionSuccessResponse.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "testId": {
+      "type": "integer"
+    },
+    "candidateId": {
+      "type": "integer"
+    },
+    "expiresAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "testId",
+    "candidateId",
+    "expiresAt"
+  ]
+}


### PR DESCRIPTION
В рамках задачи SS-78 “Api Назначение теста кандидату” реализованы автотесты для проверки корректности назначения теста кандидату через API.

Изменения:
	•	Добавлен класс SessionsApiTests с позитивным сценарием назначения теста кандидату.
	•	Добавлен обёрточный класс Sessions для работы с endpoint /api/sessions.
	•	Создана JSON-схема CreateSessionSuccessResponse.json для валидации успешного ответа (201).

Проверка:
	•	Тесты проверяют создание теста, создание кандидата и успешное назначение теста кандидату.
	•	Валидируется структура ответа по JSON-схеме.