### PR TITLE
SS-41: UI login — добавить негативные сценарии (SS-T31, SS-T62, SS-T63)

### DIFF
--- a/ui-tests/src/test/java/pages/LoginPage.java
+++ b/ui-tests/src/test/java/pages/LoginPage.java
@@ -12,14 +12,16 @@ public class LoginPage {
     public Locator usernameInput;
     public Locator passwordInput;
     public Locator loginButton;
+    public Locator emailError;
+    public Locator passwordError;
 
     public LoginPage(TestContext context) {
         this.context = context;
-
-        // Стабильные CSS-селекторы
         this.usernameInput = context.page.locator("input[name='email']");
         this.passwordInput = context.page.locator("input[name='password']");
         this.loginButton   = context.page.locator("button[type='submit']");
+        this.emailError    = context.page.locator("text=Некорректная электронная почта");
+        this.passwordError = context.page.locator("text=Пароль обязателен");
     }
 
     @Step("Login with {email} / {password}")


### PR DESCRIPTION
Что изменил:

- Добавлены UI-тесты авторизации:
  • SS-T31: Неверный логин (несуществующий email) → toast «Ошибка входа»
  • SS-T62: Пустые поля при логине → сообщения «обязательное поле»
  • SS-T63: Невалидный email (например, test@) → ошибка формата
- Уточнены методы LoginPage (явные ожидания, стабильные локаторы).
- Проверено локально: прогон зелёный, Allure-отчёт формируется.

Changes:
- Add negative login UI tests (SS-T31, SS-T62, SS-T63).
- Improve LoginPage with NETWORKIDLE waits and error locators.
- All tests passed locally (headless + headed).

Notes:
- Это продолжение задачи SS-41 (первая часть была PR #11).
- PR закрывает часть негативных сценариев по логину, оставшиеся (SS-T64, SS-T66, SS-T67, SS-T69) будут отдельными коммитами/ветками.

Как проверить:

1. Запустить локально:
   mvn -q -Dheadless=true -Dtest=tests.authandregistration.LoginTests test
2. Убедиться, что сценарии SS-T31 / SS-T62 / SS-T63 отрабатывают корректно.
3. Сгенерировать Allure-отчёт:
   mvn io.qameta.allure:allure-maven:2.12.0:report

Риск/влияние:

- Локаторы и базовые методы не затрагивают другие страницы.
- Возможен конфликт, если в проекте менялся LoginPage в параллельных ветках.