### PR TITLE
Ss 54 api tests(settings)

### DIFF
--- a/api-tests/src/test/java/dto/users/RegisterUserRequest.java
+++ b/api-tests/src/test/java/dto/users/RegisterUserRequest.java
@@ -1,0 +1,12 @@
+package dto.users;
+
+import lombok.Data;
+
+@Data
+public class RegisterUserRequest {
+    private String email;
+    private String fullName;
+    private String password;
+    private String role;
+    private boolean active;
+}

--- a/api-tests/src/test/java/dto/users/ResetPasswordRequest.java
+++ b/api-tests/src/test/java/dto/users/ResetPasswordRequest.java
@@ -1,0 +1,8 @@
+package dto.users;
+
+import lombok.Data;
+
+@Data
+public class ResetPasswordRequest {
+    private String newPassword;
+}

--- a/api-tests/src/test/java/dto/users/UpdateUserRequest.java
+++ b/api-tests/src/test/java/dto/users/UpdateUserRequest.java
@@ -1,0 +1,12 @@
+package dto.users;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateUserRequest {
+    private String role;
+    private Boolean active;
+    private String fullName;
+}

--- a/api-tests/src/test/java/tests/managetests/CreateTestApiTests.java
+++ b/api-tests/src/test/java/tests/managetests/CreateTestApiTests.java
@@ -5,6 +5,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
+import wrappers.ManageTests;
 
 import java.util.Map;
 

--- a/api-tests/src/test/java/tests/users/DeleteUserTests.java
+++ b/api-tests/src/test/java/tests/users/DeleteUserTests.java
@@ -1,36 +1,42 @@
 package tests.users;
 
-import helpers.ConfigurationReader;
-import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
 
+import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DeleteUserTests extends BaseTest {
 
+    private String id;
+
+    @BeforeEach
+    void ensurePresent() {
+        id = Users.ensureUserExists(
+                cookie,
+                get("test.user.email"),
+                get("test.user.fullName"),
+                get("test.user.password"),
+                get("test.user.role")
+        );
+    }
+
     @Test
     @DisplayName("Users: delete")
     void deleteUser_returns200() {
-        String email = ConfigurationReader.get("test.user.email");
-        String fullName = ConfigurationReader.get("test.user.fullName");
-        String password = ConfigurationReader.get("test.user.password");
-        String role = ConfigurationReader.get("test.user.role");
-
-        String id = Users.findUserIdByEmail(cookie, email);
-        if (id == null) {
-            Response create = Users.registerUser(cookie, email, fullName, password, role, true);
-            assertEquals(201, create.statusCode(), "Precondition failed: body=" + create.asString());
-            int newId = create.jsonPath().getInt("id");
-            id = String.valueOf(newId);
-        }
-
-        Response del = Users.deleteUserById(cookie, id);
+        var del = Users.deleteUserById(cookie, id);
         assertEquals(200, del.statusCode(), "Expected 200, body=" + del.asString());
         assertEquals("User deleted", del.jsonPath().getString("message"));
-        assertNull(Users.findUserIdByEmail(cookie, email), "User should be absent after delete");
+        assertNull(Users.findUserIdByEmail(cookie, get("test.user.email")));
+    }
+
+    @AfterEach
+    void cleanup() {
+        Users.deleteByEmailIfExists(cookie, get("test.user.email"));
     }
 }

--- a/api-tests/src/test/java/tests/users/DeleteUserTests.java
+++ b/api-tests/src/test/java/tests/users/DeleteUserTests.java
@@ -1,0 +1,36 @@
+package tests.users;
+
+import helpers.ConfigurationReader;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DeleteUserTests extends BaseTest {
+
+    @Test
+    @DisplayName("Users: delete")
+    void deleteUser_returns200() {
+        String email = ConfigurationReader.get("test.user.email");
+        String fullName = ConfigurationReader.get("test.user.fullName");
+        String password = ConfigurationReader.get("test.user.password");
+        String role = ConfigurationReader.get("test.user.role");
+
+        String id = Users.findUserIdByEmail(cookie, email);
+        if (id == null) {
+            Response create = Users.registerUser(cookie, email, fullName, password, role, true);
+            assertEquals(201, create.statusCode(), "Precondition failed: body=" + create.asString());
+            int newId = create.jsonPath().getInt("id");
+            id = String.valueOf(newId);
+        }
+
+        Response del = Users.deleteUserById(cookie, id);
+        assertEquals(200, del.statusCode(), "Expected 200, body=" + del.asString());
+        assertEquals("User deleted", del.jsonPath().getString("message"));
+        assertNull(Users.findUserIdByEmail(cookie, email), "User should be absent after delete");
+    }
+}

--- a/api-tests/src/test/java/tests/users/DeleteUserTests.java
+++ b/api-tests/src/test/java/tests/users/DeleteUserTests.java
@@ -11,6 +11,7 @@ import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+@DisplayName("Delete user (Settings(API))")
 public class DeleteUserTests extends BaseTest {
 
     private String id;

--- a/api-tests/src/test/java/tests/users/RegisterUserNegativeTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserNegativeTests.java
@@ -10,13 +10,11 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class UpdateUserActiveTests extends BaseTest {
-
-    private String id;
+public class RegisterUserNegativeTests extends BaseTest {
 
     @BeforeEach
     void ensurePresent() {
-        id = Users.ensureUserExists(
+        Users.ensureUserExists(
                 cookie,
                 get("test.user.email"),
                 get("test.user.fullName"),
@@ -26,15 +24,20 @@ public class UpdateUserActiveTests extends BaseTest {
     }
 
     @Test
-    @DisplayName("Users: block & unblock")
-    void block_then_unblock_returns200() {
-        var block = Users.updateUserActive(cookie, id, false);
-        assertEquals(200, block.statusCode(), "Expected 200, body=" + block.asString());
-        assertFalse(block.jsonPath().getBoolean("active"));
-
-        var unb = Users.updateUserActive(cookie, id, true);
-        assertEquals(200, unb.statusCode(), "Expected 200, body=" + unb.asString());
-        assertTrue(unb.jsonPath().getBoolean("active"));
+    @DisplayName("Users: register duplicate -> 400")
+    void registerDuplicate_returns400() {
+        var resp = Users.registerUser(
+                cookie,
+                get("test.user.email"),
+                get("test.user.fullName"),
+                get("test.user.password"),
+                get("test.user.role"),
+                true
+        );
+        assertEquals(400, resp.statusCode(), "Expected 400, body=" + resp.asString());
+        String msg = resp.jsonPath().getString("message");
+        assertNotNull(msg);
+        assertFalse(msg.isBlank());
     }
 
     @AfterEach

--- a/api-tests/src/test/java/tests/users/RegisterUserNegativeTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserNegativeTests.java
@@ -10,6 +10,7 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Register duplicate user (Settings(API)")
 public class RegisterUserNegativeTests extends BaseTest {
 
     @BeforeEach

--- a/api-tests/src/test/java/tests/users/RegisterUserTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserTests.java
@@ -11,6 +11,7 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Register user (Settings(API)")
 public class RegisterUserTests extends BaseTest {
 
     @BeforeEach

--- a/api-tests/src/test/java/tests/users/RegisterUserTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserTests.java
@@ -6,30 +6,49 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-@DisplayName("Users: register")
 public class RegisterUserTests extends BaseTest {
 
     @Test
-    @DisplayName("POST /api/register -> 201 (config data)")
+    @DisplayName("Users: register")
     void registerUser_fromConfig_returns201() {
         String fullName = ConfigurationReader.get("test.user.fullName");
         String email = ConfigurationReader.get("test.user.email");
         String password = ConfigurationReader.get("test.user.password");
         String role = ConfigurationReader.get("test.user.role");
-        String existingId = Users.findUserIdByEmail(cookie, email);
-        if (existingId != null) {
-            Response del = Users.deleteUserById(cookie, existingId);
-            assertTrue(del.statusCode() >= 200 && del.statusCode() < 300,
-                    "Предочистка: ожидали 2xx при удалении, получили " + del.statusCode());
+
+        Users.deleteByEmailIfExists(cookie, email);
+
+        Response resp = Users.registerUser(cookie, email, fullName, password, role, true);
+
+        assertEquals(201, resp.statusCode(),
+                "Expected 201 on register, body=" + resp.asString());
+        assertEquals(email, resp.jsonPath().getString("email"), "email mismatch");
+        assertEquals(role, resp.jsonPath().getString("role"), "role mismatch");
+        assertTrue(resp.jsonPath().getBoolean("active"), "active should be true");
+        assertNotNull(resp.jsonPath().getString("id"), "id should be present");
+    }
+
+    @Test
+    @DisplayName("Users: register duplicate - negative")
+    void registerDuplicate_returns400() {
+        String fullName = ConfigurationReader.get("test.user.fullName");
+        String email = ConfigurationReader.get("test.user.email");
+        String password = ConfigurationReader.get("test.user.password");
+        String role = ConfigurationReader.get("test.user.role");
+
+        String id = Users.findUserIdByEmail(cookie, email);
+        if (id == null) {
+            Response create = Users.registerUser(cookie, email, fullName, password, role, true);
+            assertEquals(201, create.statusCode(), "Precondition failed: body=" + create.asString());
         }
 
-        Response create = Users.registerUser(cookie, email, fullName, password, role, true);
-        assertEquals(201, create.statusCode(), "Ожидаем 201 при успешной регистрации");
-        assertEquals(email, create.jsonPath().getString("email"));
-        assertEquals(role, create.jsonPath().getString("role"));
-        assertTrue(create.jsonPath().getBoolean("active"));
-        assertNotNull(create.jsonPath().getString("id"), "id должен быть в ответе");
+        Response dup = Users.registerUser(cookie, email, fullName, password, role, true);
+        assertEquals(400, dup.statusCode(), "Expected 400, body=" + dup.asString());
+        String msg = dup.jsonPath().getString("message");
+        assertNotNull(msg, "error message should be present");
+        assertFalse(msg.isBlank(), "error message should not be blank");
     }
 }

--- a/api-tests/src/test/java/tests/users/RegisterUserTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserTests.java
@@ -1,0 +1,35 @@
+package tests.users;
+
+import helpers.ConfigurationReader;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Users;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Users: register")
+public class RegisterUserTests extends BaseTest {
+
+    @Test
+    @DisplayName("POST /api/register -> 201 (config data)")
+    void registerUser_fromConfig_returns201() {
+        String fullName = ConfigurationReader.get("test.user.fullName");
+        String email = ConfigurationReader.get("test.user.email");
+        String password = ConfigurationReader.get("test.user.password");
+        String role = ConfigurationReader.get("test.user.role");
+        String existingId = Users.findUserIdByEmail(cookie, email);
+        if (existingId != null) {
+            Response del = Users.deleteUserById(cookie, existingId);
+            assertTrue(del.statusCode() >= 200 && del.statusCode() < 300,
+                    "Предочистка: ожидали 2xx при удалении, получили " + del.statusCode());
+        }
+
+        Response create = Users.registerUser(cookie, email, fullName, password, role, true);
+        assertEquals(201, create.statusCode(), "Ожидаем 201 при успешной регистрации");
+        assertEquals(email, create.jsonPath().getString("email"));
+        assertEquals(role, create.jsonPath().getString("role"));
+        assertTrue(create.jsonPath().getBoolean("active"));
+        assertNotNull(create.jsonPath().getString("id"), "id должен быть в ответе");
+    }
+}

--- a/api-tests/src/test/java/tests/users/RegisterUserTests.java
+++ b/api-tests/src/test/java/tests/users/RegisterUserTests.java
@@ -2,12 +2,15 @@ package tests.users;
 
 import helpers.ConfigurationReader;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
 
+import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
+import static wrappers.Users.deleteByEmailIfExists;
 
 public class RegisterUserTests extends BaseTest {
 
@@ -19,7 +22,7 @@ public class RegisterUserTests extends BaseTest {
         String password = ConfigurationReader.get("test.user.password");
         String role = ConfigurationReader.get("test.user.role");
 
-        Users.deleteByEmailIfExists(cookie, email);
+        deleteByEmailIfExists(cookie, email);
 
         Response resp = Users.registerUser(cookie, email, fullName, password, role, true);
 
@@ -50,5 +53,13 @@ public class RegisterUserTests extends BaseTest {
         String msg = dup.jsonPath().getString("message");
         assertNotNull(msg, "error message should be present");
         assertFalse(msg.isBlank(), "error message should not be blank");
+    }
+
+    @AfterEach
+    void cleanupUser() {
+        try {
+            deleteByEmailIfExists(cookie, get("test.user.email"));
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
+++ b/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
@@ -10,6 +10,7 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisplayName("Reset user password (Settings(API)")
 public class ResetUserPasswordTests extends BaseTest {
 
     private String id;

--- a/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
+++ b/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
@@ -9,16 +9,16 @@ import wrappers.Users;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class UpdateUserRoleTests extends BaseTest {
+public class ResetUserPasswordTests extends BaseTest {
 
     @Test
-    @DisplayName("Users: update role")
-    void updateRole_toInterviewer_returns200() {
+    @DisplayName("Users: reset password")
+    void resetPassword_returns200() {
         String email = ConfigurationReader.get("test.user.email");
         String fullName = ConfigurationReader.get("test.user.fullName");
         String password = ConfigurationReader.get("test.user.password");
         String baseRole = ConfigurationReader.get("test.user.role");
-        String newRole = ConfigurationReader.get("test.user.roleChangeTo");
+        String newPassword = ConfigurationReader.get("test.user.newPassword");
 
         String id = Users.findUserIdByEmail(cookie, email);
         if (id == null) {
@@ -27,11 +27,9 @@ public class UpdateUserRoleTests extends BaseTest {
             id = String.valueOf(create.jsonPath().get("id"));
         }
 
-        Response patch = Users.updateUserRole(cookie, id, newRole);
+        Response resp = Users.resetUserPassword(cookie, id, newPassword);
 
-        assertEquals(200, patch.statusCode(), "Expected 200, body=" + patch.asString());
-        assertEquals(newRole, patch.jsonPath().getString("role"), "role mismatch");
-        assertEquals(email, patch.jsonPath().getString("email"), "email mismatch");
-        assertEquals(fullName, patch.jsonPath().getString("fullName"), "fullName mismatch");
+        assertEquals(200, resp.statusCode(), "Expected 200, body=" + resp.asString());
+        assertEquals("Password reset successfully", resp.jsonPath().getString("message"), "message mismatch");
     }
 }

--- a/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
+++ b/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
@@ -1,8 +1,7 @@
 package tests.users;
 
-import helpers.ConfigurationReader;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
@@ -10,37 +9,32 @@ import wrappers.Users;
 
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static wrappers.Users.deleteByEmailIfExists;
 
 public class ResetUserPasswordTests extends BaseTest {
+
+    private String id;
+
+    @BeforeEach
+    void ensurePresent() {
+        id = Users.ensureUserExists(
+                cookie,
+                get("test.user.email"),
+                get("test.user.fullName"),
+                get("test.user.password"),
+                get("test.user.role")
+        );
+    }
 
     @Test
     @DisplayName("Users: reset password")
     void resetPassword_returns200() {
-        String email = ConfigurationReader.get("test.user.email");
-        String fullName = ConfigurationReader.get("test.user.fullName");
-        String password = ConfigurationReader.get("test.user.password");
-        String baseRole = ConfigurationReader.get("test.user.role");
-        String newPassword = ConfigurationReader.get("test.user.newPassword");
-
-        String id = Users.findUserIdByEmail(cookie, email);
-        if (id == null) {
-            Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
-            assertEquals(201, create.statusCode(), "Precondition failed: expected 201, body=" + create.asString());
-            id = String.valueOf(create.jsonPath().getInt("id"));
-        }
-
-        Response resp = Users.resetUserPassword(cookie, id, newPassword);
-
+        var resp = Users.resetUserPassword(cookie, id, get("test.user.newPassword"));
         assertEquals(200, resp.statusCode(), "Expected 200, body=" + resp.asString());
-        assertEquals("Password reset successfully", resp.jsonPath().getString("message"), "message mismatch");
+        assertEquals("Password reset successfully", resp.jsonPath().getString("message"));
     }
 
     @AfterEach
-    void cleanupUser() {
-        try {
-            deleteByEmailIfExists(cookie, get("test.user.email"));
-        } catch (Exception ignore) {
-        }
+    void cleanup() {
+        Users.deleteByEmailIfExists(cookie, get("test.user.email"));
     }
 }

--- a/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
+++ b/api-tests/src/test/java/tests/users/ResetUserPasswordTests.java
@@ -2,12 +2,15 @@ package tests.users;
 
 import helpers.ConfigurationReader;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
 
+import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static wrappers.Users.deleteByEmailIfExists;
 
 public class ResetUserPasswordTests extends BaseTest {
 
@@ -24,12 +27,20 @@ public class ResetUserPasswordTests extends BaseTest {
         if (id == null) {
             Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
             assertEquals(201, create.statusCode(), "Precondition failed: expected 201, body=" + create.asString());
-            id = String.valueOf(create.jsonPath().get("id"));
+            id = String.valueOf(create.jsonPath().getInt("id"));
         }
 
         Response resp = Users.resetUserPassword(cookie, id, newPassword);
 
         assertEquals(200, resp.statusCode(), "Expected 200, body=" + resp.asString());
         assertEquals("Password reset successfully", resp.jsonPath().getString("message"), "message mismatch");
+    }
+
+    @AfterEach
+    void cleanupUser() {
+        try {
+            deleteByEmailIfExists(cookie, get("test.user.email"));
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
@@ -2,12 +2,15 @@ package tests.users;
 
 import helpers.ConfigurationReader;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
 
+import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
+import static wrappers.Users.deleteByEmailIfExists;
 
 public class UpdateUserActiveTests extends BaseTest {
 
@@ -33,5 +36,13 @@ public class UpdateUserActiveTests extends BaseTest {
         Response unblock = Users.updateUserActive(cookie, id, true);
         assertEquals(200, unblock.statusCode(), "Expected 200, body=" + unblock.asString());
         assertTrue(unblock.jsonPath().getBoolean("active"), "active should be true");
+    }
+
+    @AfterEach
+    void cleanupUser() {
+        try {
+            deleteByEmailIfExists(cookie, get("test.user.email"));
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
@@ -1,0 +1,37 @@
+package tests.users;
+
+import helpers.ConfigurationReader;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Users;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class UpdateUserActiveTests extends BaseTest {
+
+    @Test
+    @DisplayName("Users: block & unblock")
+    void block_then_unblock_returns200() {
+        String email = ConfigurationReader.get("test.user.email");
+        String fullName = ConfigurationReader.get("test.user.fullName");
+        String password = ConfigurationReader.get("test.user.password");
+        String baseRole = ConfigurationReader.get("test.user.role");
+
+        String id = Users.findUserIdByEmail(cookie, email);
+        if (id == null) {
+            Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
+            assertEquals(201, create.statusCode(), "Precondition failed: body=" + create.asString());
+            id = String.valueOf(create.jsonPath().getInt("id"));
+        }
+
+        Response block = Users.updateUserActive(cookie, id, false);
+        assertEquals(200, block.statusCode(), "Expected 200, body=" + block.asString());
+        assertFalse(block.jsonPath().getBoolean("active"), "active should be false");
+
+        Response unblock = Users.updateUserActive(cookie, id, true);
+        assertEquals(200, unblock.statusCode(), "Expected 200, body=" + unblock.asString());
+        assertTrue(unblock.jsonPath().getBoolean("active"), "active should be true");
+    }
+}

--- a/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserActiveTests.java
@@ -10,6 +10,7 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("Block & unblock user (Settings(API)")
 public class UpdateUserActiveTests extends BaseTest {
 
     private String id;

--- a/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
@@ -2,12 +2,15 @@ package tests.users;
 
 import helpers.ConfigurationReader;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Users;
 
+import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static wrappers.Users.deleteByEmailIfExists;
 
 public class UpdateUserRoleTests extends BaseTest {
 
@@ -24,7 +27,7 @@ public class UpdateUserRoleTests extends BaseTest {
         if (id == null) {
             Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
             assertEquals(201, create.statusCode(), "Precondition failed: expected 201, body=" + create.asString());
-            id = String.valueOf(create.jsonPath().get("id"));
+            id = String.valueOf(create.jsonPath().getInt("id"));
         }
 
         Response patch = Users.updateUserRole(cookie, id, newRole);
@@ -33,5 +36,13 @@ public class UpdateUserRoleTests extends BaseTest {
         assertEquals(newRole, patch.jsonPath().getString("role"), "role mismatch");
         assertEquals(email, patch.jsonPath().getString("email"), "email mismatch");
         assertEquals(fullName, patch.jsonPath().getString("fullName"), "fullName mismatch");
+    }
+
+    @AfterEach
+    void cleanupUser() {
+        try {
+            deleteByEmailIfExists(cookie, get("test.user.email"));
+        } catch (Exception ignore) {
+        }
     }
 }

--- a/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
@@ -1,0 +1,37 @@
+package tests.users;
+
+import helpers.ConfigurationReader;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("Users: update role")
+public class UpdateUserRoleTests extends BaseTest {
+
+    @Test
+    @DisplayName("PATCH /api/users/{id} -> 200 and role changes")
+    void updateRole_toInterviewer_returns200() {
+        String email = ConfigurationReader.get("test.user.email");
+        String fullName = ConfigurationReader.get("test.user.fullName");
+        String password = ConfigurationReader.get("test.user.password");
+        String baseRole = ConfigurationReader.get("test.user.role");
+        String newRole = ConfigurationReader.get("test.user.roleChangeTo");
+        String id = Users.findUserIdByEmail(cookie, email);
+        if (id == null) {
+            Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
+            assertEquals(201, create.statusCode(), "Предусловие: создать пользователя");
+            id = String.valueOf(create.jsonPath().get("id"));
+        }
+
+        Response patch = Users.updateUserRole(cookie, id, newRole);
+
+        assertEquals(200, patch.statusCode());
+        assertEquals(newRole, patch.jsonPath().getString("role"));
+        assertEquals(email, patch.jsonPath().getString("email"));
+        assertEquals(fullName, patch.jsonPath().getString("fullName"));
+    }
+}

--- a/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
@@ -1,8 +1,7 @@
 package tests.users;
 
-import helpers.ConfigurationReader;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
@@ -10,39 +9,33 @@ import wrappers.Users;
 
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static wrappers.Users.deleteByEmailIfExists;
 
 public class UpdateUserRoleTests extends BaseTest {
 
+    private String id;
+
+    @BeforeEach
+    void ensurePresent() {
+        id = Users.ensureUserExists(
+                cookie,
+                get("test.user.email"),
+                get("test.user.fullName"),
+                get("test.user.password"),
+                get("test.user.role")
+        );
+    }
+
     @Test
     @DisplayName("Users: update role")
-    void updateRole_toInterviewer_returns200() {
-        String email = ConfigurationReader.get("test.user.email");
-        String fullName = ConfigurationReader.get("test.user.fullName");
-        String password = ConfigurationReader.get("test.user.password");
-        String baseRole = ConfigurationReader.get("test.user.role");
-        String newRole = ConfigurationReader.get("test.user.roleChangeTo");
-
-        String id = Users.findUserIdByEmail(cookie, email);
-        if (id == null) {
-            Response create = Users.registerUser(cookie, email, fullName, password, baseRole, true);
-            assertEquals(201, create.statusCode(), "Precondition failed: expected 201, body=" + create.asString());
-            id = String.valueOf(create.jsonPath().getInt("id"));
-        }
-
-        Response patch = Users.updateUserRole(cookie, id, newRole);
-
+    void updateRole_returns200() {
+        String newRole = get("test.user.roleChangeTo");
+        var patch = Users.updateUserRole(cookie, id, newRole);
         assertEquals(200, patch.statusCode(), "Expected 200, body=" + patch.asString());
-        assertEquals(newRole, patch.jsonPath().getString("role"), "role mismatch");
-        assertEquals(email, patch.jsonPath().getString("email"), "email mismatch");
-        assertEquals(fullName, patch.jsonPath().getString("fullName"), "fullName mismatch");
+        assertEquals(newRole, patch.jsonPath().getString("role"));
     }
 
     @AfterEach
-    void cleanupUser() {
-        try {
-            deleteByEmailIfExists(cookie, get("test.user.email"));
-        } catch (Exception ignore) {
-        }
+    void cleanup() {
+        Users.deleteByEmailIfExists(cookie, get("test.user.email"));
     }
 }

--- a/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
+++ b/api-tests/src/test/java/tests/users/UpdateUserRoleTests.java
@@ -10,6 +10,7 @@ import wrappers.Users;
 import static helpers.ConfigurationReader.get;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@DisplayName("Update user role (Settings(API)")
 public class UpdateUserRoleTests extends BaseTest {
 
     private String id;

--- a/api-tests/src/test/java/wrappers/Users.java
+++ b/api-tests/src/test/java/wrappers/Users.java
@@ -3,8 +3,10 @@ package wrappers;
 import io.qameta.allure.Step;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+
 import java.util.List;
 import java.util.Map;
+
 import static io.restassured.RestAssured.given;
 
 public class Users {
@@ -12,13 +14,10 @@ public class Users {
     @Step("GET /users")
     public static Response getAllUsers(String cookie) {
         return given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
                 .header("Cookie", cookie)
-                .when()
-                .get("users")
-                .then()
-                .extract().response();
+                .when().get("users")
+                .then().extract().response();
     }
 
     @Step("POST /register")
@@ -28,55 +27,73 @@ public class Users {
                 email, fullName, password, role, active
         );
         return given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .header("Cookie", cookie)
-                .body(body)
-                .when()
-                .post("register")
-                .then()
-                .extract().response();
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).body(body)
+                .when().post("register")
+                .then().extract().response();
     }
 
     @Step("DELETE /users/{id}")
     public static Response deleteUserById(String cookie, String id) {
         return given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .header("Cookie", cookie)
-                .pathParam("id", id)
-                .when()
-                .delete("users/{id}")
-                .then()
-                .extract().response();
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .when().delete("users/{id}")
+                .then().extract().response();
+    }
+
+    @Step("PATCH /users/{id} set role")
+    public static Response updateUserRole(String cookie, String id, String role) {
+        return given()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .body(Map.of("role", role))
+                .when().patch("users/{id}")
+                .then().extract().response();
+    }
+
+    @Step("POST /users/{id}/reset-password")
+    public static Response resetUserPassword(String cookie, String id, String newPassword) {
+        return given()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .body(Map.of("newPassword", newPassword))
+                .when().post("users/{id}/reset-password")
+                .then().extract().response();
     }
 
     @Step("Find userId by email via GET /users")
     public static String findUserIdByEmail(String cookie, String email) {
         Response resp = getAllUsers(cookie);
-        List<Map<String, Object>> users = resp.jsonPath().getList("");
+        List<Map<String, Object>> users = resp.jsonPath().getList(""); // корневой массив
         if (users == null) return null;
         for (Map<String, Object> u : users) {
-            if (email.equals(u.get("email"))) {
-                return String.valueOf(u.get("id"));
-            }
+            if (email.equals(u.get("email"))) return String.valueOf(u.get("id"));
         }
         return null;
     }
 
-    @Step("PATCH /users/{id} set role")
-    public static Response updateUserRole(String cookie, String id, String role) {
-        java.util.Map<String, Object> body = java.util.Map.of("role", role);
-        return io.restassured.RestAssured.given()
-                .contentType(io.restassured.http.ContentType.JSON)
-                .accept(io.restassured.http.ContentType.JSON)
-                .header("Cookie", cookie)
-                .pathParam("id", id)
-                .body(body)
-                .when()
-                .patch("users/{id}")
-                .then()
-                .extract().response();
+    @Step("Delete user by email if exists")
+    public static void deleteByEmailIfExists(String cookie, String email) {
+        String id = findUserIdByEmail(cookie, email);
+        if (id != null) {
+            Response del = deleteUserById(cookie, id);
+            if (del.statusCode() < 200 || del.statusCode() >= 300) {
+                throw new AssertionError("Cleanup failed: expected 2xx, got " + del.statusCode()
+                        + " body=" + del.asString());
+            }
+        }
     }
+
+    @Step("PATCH /users/{id} set active")
+    public static Response updateUserActive(String cookie, String id, boolean active) {
+        return given()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .body(Map.of("active", active))
+                .when().patch("users/{id}")
+                .then().extract().response();
+    }
+
 }
 

--- a/api-tests/src/test/java/wrappers/Users.java
+++ b/api-tests/src/test/java/wrappers/Users.java
@@ -1,5 +1,8 @@
 package wrappers;
 
+import dto.users.RegisterUserRequest;
+import dto.users.ResetPasswordRequest;
+import dto.users.UpdateUserRequest;
 import io.qameta.allure.Step;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -20,16 +23,59 @@ public class Users {
                 .then().extract().response();
     }
 
-    @Step("POST /register")
-    public static Response registerUser(String cookie, String email, String fullName, String password, String role, boolean active) {
-        String body = String.format(
-                "{\"email\":\"%s\",\"fullName\":\"%s\",\"password\":\"%s\",\"role\":\"%s\",\"active\":%s}",
-                email, fullName, password, role, active
-        );
+    @Step("POST /register (DTO)")
+    public static Response registerUser(String cookie, RegisterUserRequest req) {
         return given()
                 .contentType(ContentType.JSON).accept(ContentType.JSON)
-                .header("Cookie", cookie).body(body)
+                .header("Cookie", cookie)
+                .body(req)
                 .when().post("register")
+                .then().extract().response();
+    }
+
+    public static Response registerUser(String cookie, String email, String fullName, String password, String role, boolean active) {
+        RegisterUserRequest r = new RegisterUserRequest();
+        r.setEmail(email);
+        r.setFullName(fullName);
+        r.setPassword(password);
+        r.setRole(role);
+        r.setActive(active);
+        return registerUser(cookie, r);
+    }
+
+    @Step("PATCH /users/{id} (DTO)")
+    public static Response updateUser(String cookie, String id, UpdateUserRequest req) {
+        return given()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .body(req)
+                .when().patch("users/{id}")
+                .then().extract().response();
+    }
+
+    @Step("PATCH /users/{id} set role")
+    public static Response updateUserRole(String cookie, String id, String role) {
+        UpdateUserRequest u = new UpdateUserRequest();
+        u.setRole(role);
+        return updateUser(cookie, id, u);
+    }
+
+    @Step("PATCH /users/{id} set active")
+    public static Response updateUserActive(String cookie, String id, boolean active) {
+        UpdateUserRequest u = new UpdateUserRequest();
+        u.setActive(active);
+        return updateUser(cookie, id, u);
+    }
+
+    @Step("POST /users/{id}/reset-password")
+    public static Response resetUserPassword(String cookie, String id, String newPassword) {
+        ResetPasswordRequest r = new ResetPasswordRequest();
+        r.setNewPassword(newPassword);
+        return given()
+                .contentType(ContentType.JSON).accept(ContentType.JSON)
+                .header("Cookie", cookie).pathParam("id", id)
+                .body(r)
+                .when().post("users/{id}/reset-password")
                 .then().extract().response();
     }
 
@@ -42,33 +88,16 @@ public class Users {
                 .then().extract().response();
     }
 
-    @Step("PATCH /users/{id} set role")
-    public static Response updateUserRole(String cookie, String id, String role) {
-        return given()
-                .contentType(ContentType.JSON).accept(ContentType.JSON)
-                .header("Cookie", cookie).pathParam("id", id)
-                .body(Map.of("role", role))
-                .when().patch("users/{id}")
-                .then().extract().response();
-    }
-
-    @Step("POST /users/{id}/reset-password")
-    public static Response resetUserPassword(String cookie, String id, String newPassword) {
-        return given()
-                .contentType(ContentType.JSON).accept(ContentType.JSON)
-                .header("Cookie", cookie).pathParam("id", id)
-                .body(Map.of("newPassword", newPassword))
-                .when().post("users/{id}/reset-password")
-                .then().extract().response();
-    }
 
     @Step("Find userId by email via GET /users")
     public static String findUserIdByEmail(String cookie, String email) {
         Response resp = getAllUsers(cookie);
-        List<Map<String, Object>> users = resp.jsonPath().getList(""); // корневой массив
+        List<Map<String, Object>> users = resp.jsonPath().getList("");
         if (users == null) return null;
         for (Map<String, Object> u : users) {
-            if (email.equals(u.get("email"))) return String.valueOf(u.get("id"));
+            if (email.equals(u.get("email"))) {
+                return String.valueOf(u.get("id"));
+            }
         }
         return null;
     }
@@ -76,24 +105,16 @@ public class Users {
     @Step("Delete user by email if exists")
     public static void deleteByEmailIfExists(String cookie, String email) {
         String id = findUserIdByEmail(cookie, email);
-        if (id != null) {
-            Response del = deleteUserById(cookie, id);
-            if (del.statusCode() < 200 || del.statusCode() >= 300) {
-                throw new AssertionError("Cleanup failed: expected 2xx, got " + del.statusCode()
-                        + " body=" + del.asString());
-            }
-        }
+        if (id != null) deleteUserById(cookie, id);
     }
 
-    @Step("PATCH /users/{id} set active")
-    public static Response updateUserActive(String cookie, String id, boolean active) {
-        return given()
-                .contentType(ContentType.JSON).accept(ContentType.JSON)
-                .header("Cookie", cookie).pathParam("id", id)
-                .body(Map.of("active", active))
-                .when().patch("users/{id}")
-                .then().extract().response();
+    @Step("Ensure user exists -> return id")
+    public static String ensureUserExists(String cookie, String email, String fullName, String password, String role) {
+        String id = findUserIdByEmail(cookie, email);
+        if (id != null) return id;
+        Response r = registerUser(cookie, email, fullName, password, role, true);
+        if (r.statusCode() != 201) throw new AssertionError("Can't create user, body=" + r.asString());
+        return String.valueOf(r.jsonPath().getInt("id"));
     }
-
 }
 

--- a/api-tests/src/test/java/wrappers/Users.java
+++ b/api-tests/src/test/java/wrappers/Users.java
@@ -1,0 +1,82 @@
+package wrappers;
+
+import io.qameta.allure.Step;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.Map;
+import static io.restassured.RestAssured.given;
+
+public class Users {
+
+    @Step("GET /users")
+    public static Response getAllUsers(String cookie) {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Cookie", cookie)
+                .when()
+                .get("users")
+                .then()
+                .extract().response();
+    }
+
+    @Step("POST /register")
+    public static Response registerUser(String cookie, String email, String fullName, String password, String role, boolean active) {
+        String body = String.format(
+                "{\"email\":\"%s\",\"fullName\":\"%s\",\"password\":\"%s\",\"role\":\"%s\",\"active\":%s}",
+                email, fullName, password, role, active
+        );
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Cookie", cookie)
+                .body(body)
+                .when()
+                .post("register")
+                .then()
+                .extract().response();
+    }
+
+    @Step("DELETE /users/{id}")
+    public static Response deleteUserById(String cookie, String id) {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(ContentType.JSON)
+                .header("Cookie", cookie)
+                .pathParam("id", id)
+                .when()
+                .delete("users/{id}")
+                .then()
+                .extract().response();
+    }
+
+    @Step("Find userId by email via GET /users")
+    public static String findUserIdByEmail(String cookie, String email) {
+        Response resp = getAllUsers(cookie);
+        List<Map<String, Object>> users = resp.jsonPath().getList("");
+        if (users == null) return null;
+        for (Map<String, Object> u : users) {
+            if (email.equals(u.get("email"))) {
+                return String.valueOf(u.get("id"));
+            }
+        }
+        return null;
+    }
+
+    @Step("PATCH /users/{id} set role")
+    public static Response updateUserRole(String cookie, String id, String role) {
+        java.util.Map<String, Object> body = java.util.Map.of("role", role);
+        return io.restassured.RestAssured.given()
+                .contentType(io.restassured.http.ContentType.JSON)
+                .accept(io.restassured.http.ContentType.JSON)
+                .header("Cookie", cookie)
+                .pathParam("id", id)
+                .body(body)
+                .when()
+                .patch("users/{id}")
+                .then()
+                .extract().response();
+    }
+}
+

--- a/api-tests/src/test/resources/config.properties
+++ b/api-tests/src/test/resources/config.properties
@@ -1,3 +1,10 @@
 URL=https://skillchecker.tech/
 email=admin@skillchecker.tech
 password=admin123
+
+test.user.fullName=Autotest User
+test.user.password=Qwerty123!
+test.user.email=test13mail@gmail.com
+test.user.role=recruiter
+test.user.roleChangeTo=interviewer
+test.user.newPassword=Q1w2e3r4!


### PR DESCRIPTION
Покрыт Users API минимальным, но полным набором тестов:

RegisterUserTests — POST /api/register → 201
RegisterUserNegativeTests — повторная регистрация тем же email → 400
UpdateUserRoleTests — PATCH /api/users/{id} (role) → 200
ResetUserPasswordTests — POST /api/users/{id}/reset-password → 200
UpdateUserActiveTests — PATCH /api/users/{id} (active: block/unblock) → 200
DeleteUserTests — DELETE /api/users/{id} → 200

Вынесены минимальные DTO для запросов:
RegisterUserRequest (@Data)
UpdateUserRequest (@Data + @JsonInclude(NON_NULL) — чтобы PATCH отправлял только заданные поля)
ResetPasswordRequest (@Data)
Обновлён wrappers.Users:
Методы принимают DTO, единый стиль RestAssured.

Хелперы: ensureUserExists, deleteByEmailIfExists, findUserIdByEmail.

Тесты упрощены:
Предусловия вынесены в @BeforeEach (создание/удаление тестового пользователя).
Единый @AfterEach с best-effort очисткой: тестовый пользователь удаляется после каждого теста.
Исправлен парсинг id из ответов: jsonPath().getInt("id") → String.valueOf(...) (устранён ClassCastException).