### PR TITLE
Auth UI tests: SS-T30/31/32/62/66/69 + LoginPage/DashboardPage/Toast

### DIFF
--- a/ui-tests/src/test/java/pages/DashboardPage.java
+++ b/ui-tests/src/test/java/pages/DashboardPage.java
@@ -14,32 +14,27 @@ public class DashboardPage {
     public final Locator candidatesCounter;
     public final Locator pendingSessionsCounter;
     public final Locator completedSessionsCounter;
-
     public final Locator createTestButton;
     public final Locator addCandidateButton;
-
     public final Locator createTestModalNameInput;
     public final Locator addCandidateModalNameInput;
-
     public final Locator recentActivityListContainer;
     public final Locator recentActivityListItems;
+    public final Locator logoutButton;
 
     public DashboardPage(TestContext context) {
         this.context = context;
-
         this.activeTestsCounter       = context.page.locator("[data-testid=\"active-tests-card\"] .text-2xl");
         this.candidatesCounter        = context.page.locator("[data-testid=\"total-candidates-card\"] .text-2xl");
         this.pendingSessionsCounter   = context.page.locator("[data-testid=\"pending-sessions-card\"] .text-2xl");
         this.completedSessionsCounter = context.page.locator("[data-testid=\"completed-sessions-card\"] .text-2xl");
-
         this.createTestButton   = context.page.locator("[data-testid=\"quick-action-create-test\"]");
         this.addCandidateButton = context.page.locator("[data-testid=\"quick-action-add-candidate\"]");
-
         this.createTestModalNameInput   = context.page.getByLabel("Название теста");
         this.addCandidateModalNameInput = context.page.getByLabel("Имя");
-
         this.recentActivityListContainer = context.page.locator("[data-testid=\"recent-activity-card\"]");
         this.recentActivityListItems     = context.page.locator("[data-testid=\"recent-activity-list\"] > div");
+        this.logoutButton = context.page.locator("[data-testid='logout-button']");
     }
 
     @Step("Открыть дашборд")
@@ -50,7 +45,7 @@ public class DashboardPage {
         return this;
     }
 
-    @Step("Дождаться готовности дашборда (ключевой виджет + NETWORKIDLE)")
+    @Step("Дождаться готовности дашборда")
     public DashboardPage waitUntilReady() {
         activeTestsCounter.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         context.page.waitForLoadState(LoadState.NETWORKIDLE);
@@ -62,53 +57,54 @@ public class DashboardPage {
         return digits.isEmpty() ? 0 : Integer.parseInt(digits);
     }
 
-    @Step("Открыть модалку 'Создать тест' и дождаться поля ввода названия")
+    @Step("Открыть модалку создания теста")
     public Locator openCreateTestModalAndWaitInput() {
         createTestButton.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         createTestButton.click();
-
         if (createTestModalNameInput.count() > 0) {
-            createTestModalNameInput.waitFor(new Locator.WaitForOptions()
-                    .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+            createTestModalNameInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
             return createTestModalNameInput;
         }
         Locator en = context.page.getByLabel("Test name");
         if (en.count() > 0) {
-            en.waitFor(new Locator.WaitForOptions()
-                    .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+            en.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
             return en;
         }
         Locator dialog = context.page.locator("div[role='dialog']").first();
-        dialog.waitFor(new Locator.WaitForOptions()
-                .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+        dialog.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
         Locator anyInput = dialog.locator("input, textarea").first();
-        anyInput.waitFor(new Locator.WaitForOptions()
-                .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+        anyInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
         return anyInput;
     }
 
-    @Step("Открыть модалку 'Добавить кандидата' и дождаться поля ввода имени")
+    @Step("Открыть модалку добавления кандидата")
     public Locator openAddCandidateModalAndWaitInput() {
         addCandidateButton.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
         addCandidateButton.click();
-
         if (addCandidateModalNameInput.count() > 0) {
-            addCandidateModalNameInput.waitFor(new Locator.WaitForOptions()
-                    .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+            addCandidateModalNameInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
             return addCandidateModalNameInput;
         }
         Locator en = context.page.getByLabel("Name");
         if (en.count() > 0) {
-            en.waitFor(new Locator.WaitForOptions()
-                    .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+            en.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
             return en;
         }
         Locator dialog = context.page.locator("div[role='dialog']").first();
-        dialog.waitFor(new Locator.WaitForOptions()
-                .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+        dialog.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
         Locator anyInput = dialog.locator("input, textarea").first();
-        anyInput.waitFor(new Locator.WaitForOptions()
-                .setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
+        anyInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10_000));
         return anyInput;
+    }
+
+    @Step("Logout")
+    public LoginPage logout() {
+        context.page.evaluate("window.scrollTo(0, document.body.scrollHeight)");
+        logoutButton.scrollIntoViewIfNeeded();
+        logoutButton.click();
+        LoginPage login = new LoginPage(context);
+        login.usernameInput.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE).setTimeout(10000));
+        context.page.waitForLoadState(LoadState.NETWORKIDLE);
+        return login;
     }
 }

--- a/ui-tests/src/test/java/pages/LoginPage.java
+++ b/ui-tests/src/test/java/pages/LoginPage.java
@@ -1,19 +1,19 @@
 package pages;
 
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.options.LoadState;
 import context.TestContext;
-import com.microsoft.playwright.Locator;
 import io.qameta.allure.Step;
 import utils.ConfigurationReader;
 
 public class LoginPage {
-    TestContext context;
+    private final TestContext context;
 
-    public Locator usernameInput;
-    public Locator passwordInput;
-    public Locator loginButton;
-    public Locator emailError;
-    public Locator passwordError;
+    public final Locator usernameInput;
+    public final Locator passwordInput;
+    public final Locator loginButton;
+    public final Locator emailError;
+    public final Locator passwordError;
 
     public LoginPage(TestContext context) {
         this.context = context;
@@ -22,6 +22,10 @@ public class LoginPage {
         this.loginButton   = context.page.locator("button[type='submit']");
         this.emailError    = context.page.locator("text=Некорректная электронная почта");
         this.passwordError = context.page.locator("text=Пароль обязателен");
+    }
+
+    public Locator loginButton() {
+        return loginButton;
     }
 
     @Step("Login with {email} / {password}")
@@ -36,7 +40,8 @@ public class LoginPage {
     @Step("Проверяем, что открыта страница логина")
     public boolean isAtLoginPage(String baseUrl) {
         String url = context.page.url();
-        return url.equals(baseUrl) || url.endsWith("/login");
+        String base = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+        return url.equals(base) || url.startsWith(base + "login") || url.contains("/login?");
     }
 
     @Step("Открыть страницу логина")

--- a/ui-tests/src/test/java/tests/authandregistration/LoginTests.java
+++ b/ui-tests/src/test/java/tests/authandregistration/LoginTests.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Feature("Auth")
 @Owner("Ko.Herasymets")
 @Tag("ui")
+@DisplayName("Auth UI Tests — Login & Logout scenarios")
 public class LoginTests extends BaseTest {
     @Override
     protected boolean needAuthCookie() { return false; }
@@ -26,8 +27,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T30")
-    @Story("SS-T30 Успешный вход")
-    @DisplayName("[SS-T30] Login: успешная авторизация валидными данными")
+    @Story("Успешный вход")
+    @Severity(SeverityLevel.CRITICAL)
+    @DisplayName("[SS-T30] Auth / Login — успешная авторизация валидными данными")
     void shouldLoginSuccessfully_SS_T30() {
         String email = ConfigurationReader.get("email");
         String password = ConfigurationReader.get("password");
@@ -44,8 +46,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T31")
-    @Story("SS-T31 Неверный логин")
-    @DisplayName("[SS-T31] Login: неверный email → ошибка авторизации")
+    @Story("Неверный email")
+    @Severity(SeverityLevel.NORMAL)
+    @DisplayName("[SS-T31] Auth / Login — неверный email → ошибка авторизации")
     void shouldShowErrorOnWrongEmail_SS_T31() {
         String wrongEmail = "not-exists+" + System.currentTimeMillis() + "@example.com";
         String password = ConfigurationReader.get("password");
@@ -54,8 +57,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T32")
-    @Story("SS-T32 Неверный пароль")
-    @DisplayName("[SS-T32] Login: неверный пароль → ошибка авторизации")
+    @Story("Неверный пароль")
+    @Severity(SeverityLevel.NORMAL)
+    @DisplayName("[SS-T32] Auth / Login — неверный пароль → ошибка авторизации")
     void shouldShowErrorOnWrongPassword_SS_T32() {
         String email = ConfigurationReader.get("email");
         String wrongPassword = "wrongPass!" + System.currentTimeMillis();
@@ -64,8 +68,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T62")
-    @Story("SS-T62 Валидации пустых полей")
-    @DisplayName("[SS-T62] Login: ошибки валидации при пустых/частично заполненных полях")
+    @Story("Ошибки валидации при пустых/частично заполненных полях")
+    @Severity(SeverityLevel.MINOR)
+    @DisplayName("[SS-T62] Auth / Validation — ошибки при пустых/частично заполненных полях")
     void shouldShowValidationErrorsOnEmptyFields_SS_T62() {
         LoginPage login = new LoginPage(context).open();
 
@@ -84,8 +89,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T66")
-    @Story("SS-T66 Доступ к защищённой странице без авторизации")
-    @DisplayName("[SS-T66] Access: переход на /dashboard без логина ведёт на /login")
+    @Story("Доступ к /dashboard без авторизации")
+    @Severity(SeverityLevel.NORMAL)
+    @DisplayName("[SS-T66] Auth / Access — переход на /dashboard без логина ведёт на /login")
     void shouldRedirectToLoginWhenOpenDashboardWithoutAuth_SS_T66() {
         context.page.navigate(baseUrl() + "dashboard");
         context.page.waitForLoadState(LoadState.NETWORKIDLE);
@@ -94,8 +100,9 @@ public class LoginTests extends BaseTest {
 
     @Test
     @TmsLink("SS-T69")
-    @Story("SS-T69 Logout и защита после выхода")
-    @DisplayName("[SS-T69] Logout: после выхода /dashboard недоступен (редирект на /login)")
+    @Story("Logout: защита после выхода")
+    @Severity(SeverityLevel.CRITICAL)
+    @DisplayName("[SS-T69] Auth / Logout — после выхода /dashboard недоступен (редирект на /login)")
     void shouldDenyDashboardAfterLogout_SS_T69() {
         new LoginPage(context).open().login(ConfigurationReader.get("email"), ConfigurationReader.get("password"));
         new DashboardPage(context).waitUntilReady().logout();

--- a/ui-tests/src/test/java/tests/authandregistration/LoginTests.java
+++ b/ui-tests/src/test/java/tests/authandregistration/LoginTests.java
@@ -1,79 +1,135 @@
 package tests.authandregistration;
 
-import io.qameta.allure.Epic;
-import io.qameta.allure.Feature;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.microsoft.playwright.options.LoadState;
+import io.qameta.allure.*;
+import org.junit.jupiter.api.*;
+import pages.DashboardPage;
 import pages.LoginPage;
 import pages.components.Toast;
 import tests.BaseTest;
 import utils.ConfigurationReader;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Epic("Auth")
-@Feature("Login")
-@DisplayName("Login tests")
+@Epic("UI Tests")
+@Feature("Auth")
+@Owner("Ko.Herasymets")
+@Tag("ui")
 public class LoginTests extends BaseTest {
-
     @Override
-    protected boolean needAuthCookie() {
-        return false;
+    protected boolean needAuthCookie() { return false; }
+
+    private String baseUrl() {
+        String base = ConfigurationReader.get("URL");
+        return base.endsWith("/") ? base : base + "/";
     }
 
     @Test
-    @DisplayName("SS-T30: Валидные email/пароль → редирект на /dashboard")
-    void successfulLogin_redirectsToDashboard() {
-        String base = ConfigurationReader.get("URL");
+    @TmsLink("SS-T30")
+    @Story("SS-T30 Успешный вход")
+    @DisplayName("[SS-T30] Login: успешная авторизация валидными данными")
+    void shouldLoginSuccessfully_SS_T30() {
         String email = ConfigurationReader.get("email");
         String password = ConfigurationReader.get("password");
 
         new LoginPage(context).open().login(email, password);
-        context.page.waitForURL(base + "dashboard");
+        new DashboardPage(context).waitUntilReady();
 
-        assertEquals(base + "dashboard", context.page.url());
+        boolean onDashboard = context.page.url().endsWith("/dashboard");
+        boolean toastOk = new Toast(context.page).waitAppear(8000)
+                .containsAny("Успешный вход", "Добро пожаловать", "System Administrator");
+
+        assertTrue(onDashboard || toastOk, "После логина не увидели Dashboard или приветственный тост");
     }
 
     @Test
-    @DisplayName("SS-T31: Неверный логин → toast 'Ошибка входа'")
-    void wrongLogin_showsErrorToast() {
-        String base = ConfigurationReader.get("URL");
-
-        new LoginPage(context).open().login("not.exist.user@example.com", "AnyPassword#1");
-
-        Toast toast = new Toast(context.page).waitOpen();
-        assertEquals("Ошибка входа", toast.titleText());
-        assertTrue(new LoginPage(context).isAtLoginPage(base));
+    @TmsLink("SS-T31")
+    @Story("SS-T31 Неверный логин")
+    @DisplayName("[SS-T31] Login: неверный email → ошибка авторизации")
+    void shouldShowErrorOnWrongEmail_SS_T31() {
+        String wrongEmail = "not-exists+" + System.currentTimeMillis() + "@example.com";
+        String password = ConfigurationReader.get("password");
+        assertInvalidCredentials(wrongEmail, password);
     }
 
     @Test
-    @DisplayName("SS-T32: Неверный пароль → toast 'Ошибка входа'")
-    void wrongPassword_showsErrorToast() {
-        String base = ConfigurationReader.get("URL");
+    @TmsLink("SS-T32")
+    @Story("SS-T32 Неверный пароль")
+    @DisplayName("[SS-T32] Login: неверный пароль → ошибка авторизации")
+    void shouldShowErrorOnWrongPassword_SS_T32() {
         String email = ConfigurationReader.get("email");
-
-        new LoginPage(context).open().login(email, "DefinitelyWrong#123");
-
-        Toast toast = new Toast(context.page).waitOpen();
-        assertEquals("Ошибка входа", toast.titleText());
-        assertTrue(toast.bodyText().contains("401"));
-        assertTrue(new LoginPage(context).isAtLoginPage(base));
+        String wrongPassword = "wrongPass!" + System.currentTimeMillis();
+        assertInvalidCredentials(email, wrongPassword);
     }
 
     @Test
-    @DisplayName("SS-T62: Пустые поля при логине → обязательные поля")
-    void emptyFields_showRequiredErrors() {
-        LoginPage loginPage = new LoginPage(context).open();
-        loginPage.login("", "");
-        assertTrue(loginPage.emailError.isVisible());
-        assertTrue(loginPage.passwordError.isVisible());
+    @TmsLink("SS-T62")
+    @Story("SS-T62 Валидации пустых полей")
+    @DisplayName("[SS-T62] Login: ошибки валидации при пустых/частично заполненных полях")
+    void shouldShowValidationErrorsOnEmptyFields_SS_T62() {
+        LoginPage login = new LoginPage(context).open();
+
+        login.login("", "");
+        assertTrue(login.emailError.isVisible());
+        assertTrue(login.passwordError.isVisible());
+
+        login.login("", ConfigurationReader.get("password"));
+        assertTrue(login.emailError.isVisible());
+        assertTrue(!login.passwordError.isVisible());
+
+        login.login(ConfigurationReader.get("email"), "");
+        assertTrue(login.passwordError.isVisible());
+        assertTrue(!login.emailError.isVisible());
     }
 
     @Test
-    @DisplayName("SS-T63: Невалидный email → ошибка формата")
-    void invalidEmail_showsFormatError() {
-        LoginPage loginPage = new LoginPage(context).open();
-        loginPage.login("test@", "SomePassword#1");
-        assertTrue(loginPage.emailError.isVisible());
+    @TmsLink("SS-T66")
+    @Story("SS-T66 Доступ к защищённой странице без авторизации")
+    @DisplayName("[SS-T66] Access: переход на /dashboard без логина ведёт на /login")
+    void shouldRedirectToLoginWhenOpenDashboardWithoutAuth_SS_T66() {
+        context.page.navigate(baseUrl() + "dashboard");
+        context.page.waitForLoadState(LoadState.NETWORKIDLE);
+        assertTrue(new LoginPage(context).isAtLoginPage(baseUrl()));
+    }
+
+    @Test
+    @TmsLink("SS-T69")
+    @Story("SS-T69 Logout и защита после выхода")
+    @DisplayName("[SS-T69] Logout: после выхода /dashboard недоступен (редирект на /login)")
+    void shouldDenyDashboardAfterLogout_SS_T69() {
+        new LoginPage(context).open().login(ConfigurationReader.get("email"), ConfigurationReader.get("password"));
+        new DashboardPage(context).waitUntilReady().logout();
+
+        assertTrue(new LoginPage(context).isAtLoginPage(baseUrl()));
+
+        assertTrue(
+                new Toast(context.page).waitAppear(7000)
+                        .containsAny("Выход выполнен", "Вы вышли из системы", "Signed out"),
+                "Ожидали тост об успешном выходе"
+        );
+
+        context.page.navigate(baseUrl() + "dashboard");
+        context.page.waitForLoadState(LoadState.NETWORKIDLE);
+        assertTrue(new LoginPage(context).isAtLoginPage(baseUrl()));
+    }
+
+    private void assertInvalidCredentials(String email, String password) {
+        new LoginPage(context).open().login(email, password);
+        Toast toast = new Toast(context.page).waitAppear(8000);
+        String title = toast.titleText();
+        String body = toast.bodyText();
+
+        boolean looksLikeInvalid =
+                containsAny(title, "Ошибка входа", "Неверные", "Invalid") ||
+                        containsAny(body, "Ошибка входа", "Неверные", "Invalid credentials", "401");
+
+        assertTrue(looksLikeInvalid,
+                "Ожидали тост об ошибке авторизации. title=\"" + title + "\", body=\"" + body + "\"");
+    }
+
+    private boolean containsAny(String text, String... needles) {
+        String t = text == null ? "" : text.toLowerCase();
+        for (String n : needles) if (t.contains(n.toLowerCase())) return true;
+        return false;
     }
 }


### PR DESCRIPTION
Scope / Что входит
tests.authandregistration.LoginTests
[SS-T30] успешная авторизация валидными данными
[SS-T31] ошибка при неверном email
[SS-T32] ошибка при неверном пароле
[SS-T62] ошибки валидации при пустых/частично заполненных полях
[SS-T66] переход на /dashboard без авторизации → редирект на /login
[SS-T69] logout делает /dashboard недоступным (редирект на /login) и показывает тост об успешном выходе

pages/
LoginPage — локаторы полей/кнопки/ошибок, метод open(), login(), isAtLoginPage()
DashboardPage — ожидание готовности, logout() с ожиданием логина
components/Toast — удобные методы чтения заголовка/тела и containsAny(...)

Allure-метки: @Epic("UI Tests"), @Feature("Auth"), @Owner, @Tag("ui"), @TmsLink для каждого теста

Как прогнать локально
mvn -q -Dtest=tests.authandregistration.LoginTests test

Конфиги берутся из ConfigurationReader (URL, email, password).

Верификация / Что проверял
При валидном логине попадаем на /dashboard или видим тост “Успешный вход”.
При невалидных данных показывается тост об ошибке (рус/eng формулировки учтены).
Пустые поля подсвечивают соответствующие ошибки (email/password).
Холодный заход на /dashboard без куки → редирект на /login.
После logout() — тост “Выход выполнен” и повторный заход на /dashboard снова ведёт на /login.