### PR TITLE
test(api): add Auth & Dashboard API tests (SS-T30, T31, T32, T62, T66, T69)

### DIFF
--- a/api-tests/src/test/java/helpers/ResponseVerifier.java
+++ b/api-tests/src/test/java/helpers/ResponseVerifier.java
@@ -4,6 +4,8 @@ import io.qameta.allure.Step;
 import io.restassured.module.jsv.JsonSchemaValidator;
 import io.restassured.response.Response;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class ResponseVerifier {
 
     @Step("Verify JSON schema and status code is {expectedStatusCode}")
@@ -13,9 +15,21 @@ public class ResponseVerifier {
                 .body(JsonSchemaValidator.matchesJsonSchemaInClasspath(pathToSchema));
     }
 
-    @Step("Verify  status code is {expectedStatusCode}")
+    @Step("Verify status code is {expectedStatusCode}")
     public static void verifyResponse(Response response, int expectedStatusCode) {
         response.then().assertThat()
                 .statusCode(expectedStatusCode);
+    }
+
+    @Step("Verify cookie {cookieName} is set")
+    public static void hasCookie(Response response, String cookieName) {
+        String c = response.getCookie(cookieName);
+        assertTrue(c != null && !c.isBlank());
+    }
+
+    @Step("Verify unauthorized (401 or 403)")
+    public static void verifyUnauthorized(Response response) {
+        int code = response.getStatusCode();
+        assertTrue(code == 401 || code == 403);
     }
 }

--- a/api-tests/src/test/java/tests/auth/LoginTests.java
+++ b/api-tests/src/test/java/tests/auth/LoginTests.java
@@ -1,33 +1,69 @@
 package tests.auth;
 
 import helpers.ConfigurationReader;
+import helpers.ResponseVerifier;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import tests.BaseTest;
 import wrappers.Auth;
 
-@DisplayName("Login tests")
+@Epic("API Tests")
+@Feature("Auth/Login")
+@DisplayName("Auth/Login tests (SS-T30, SS-T31, SS-T32, SS-T62)")
 public class LoginTests extends BaseTest {
 
     @Test
-    @DisplayName("Check successful login")
-    void successfulLogin() {
+    @DisplayName("[SS-T30] POS — успешная авторизация: 200 + schema + cookie + /user 200")
+    void login_ok() {
         String email = ConfigurationReader.get("email");
         String password = ConfigurationReader.get("password");
 
-        Response response = Auth.loginUser(email, password);
-        Auth.verifySuccessfulLoginResponse(response);
+        Response login = Auth.loginUser(email, password);
+        Auth.verifySuccessfulLoginResponse(login);
+        ResponseVerifier.hasCookie(login, "connect.sid");
+
+        String cookieHeader = "connect.sid=" + login.getCookie("connect.sid");
+        Response me = Auth.getCurrentUser(cookieHeader);
+        ResponseVerifier.verifyResponse(me, 200);
     }
 
     @Test
-    @DisplayName("Check unsuccessful login")
-    void unsuccessfulLogin() {
-        String invalidEmail = "wrong@email.com";
-        String invalidPassword = "wrongpass";
+    @DisplayName("[SS-T31] NEG — неверный логин: 401 + ErrorResponse")
+    void invalid_email() {
+        String validPassword = ConfigurationReader.get("password");
+        Response resp = Auth.loginUser("wrong_user@test.com", validPassword);
+        Auth.verifyUnsuccessfulLoginResponse(resp);
+    }
 
-        Response response = Auth.loginUser(invalidEmail, invalidPassword);
-        Auth.verifyUnsuccessfulLoginResponse(response);
+    @Test
+    @DisplayName("[SS-T32] NEG — неверный пароль: 401 + ErrorResponse")
+    void invalid_password() {
+        String validEmail = ConfigurationReader.get("email");
+        Response resp = Auth.loginUser(validEmail, "wrongpass");
+        Auth.verifyUnsuccessfulLoginResponse(resp);
+    }
+
+    @Test
+    @DisplayName("[SS-T62] NEG — пустые поля (email и пароль): 400 + ErrorResponse")
+    void both_empty() {
+        Response r = Auth.loginUser("", "");
+        ResponseVerifier.verifyResponse(r, 400, "schemas/auth/ErrorResponse.json");
+    }
+
+    @Test
+    @DisplayName("[SS-T62] NEG — пустой email: 400 + ErrorResponse")
+    void email_empty() {
+        Response r = Auth.loginUser("", "AnyPass123!");
+        ResponseVerifier.verifyResponse(r, 400, "schemas/auth/ErrorResponse.json");
+    }
+
+    @Test
+    @DisplayName("[SS-T62] NEG — пустой пароль: 400 + ErrorResponse")
+    void password_empty() {
+        Response r = Auth.loginUser("any@mail.com", "");
+        ResponseVerifier.verifyResponse(r, 400, "schemas/auth/ErrorResponse.json");
     }
 }
-

--- a/api-tests/src/test/java/tests/auth/LogoutTests.java
+++ b/api-tests/src/test/java/tests/auth/LogoutTests.java
@@ -1,0 +1,27 @@
+package tests.auth;
+
+import helpers.ConfigurationReader;
+import helpers.ResponseVerifier;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Auth;
+import wrappers.Dashboard;
+
+@DisplayName("[SS-T69] ACC Auth/Logout — Logout делает Dashboard недоступной")
+public class LogoutTests extends BaseTest {
+
+    @Test
+    @DisplayName("локальная сессия: logout 200 → stats 401/403")
+    void logout_then_forbidden() {
+        Response login = Auth.loginUser(ConfigurationReader.get("email"), ConfigurationReader.get("password"));
+        String localCookie = "connect.sid=" + login.getCookie("connect.sid");
+
+        Response out = Auth.logout(localCookie);
+        ResponseVerifier.verifyResponse(out, 200);
+
+        Response stats = Dashboard.getStats(localCookie);
+        ResponseVerifier.verifyUnauthorized(stats);
+    }
+}

--- a/api-tests/src/test/java/tests/dashboard/DashboardAccessTests.java
+++ b/api-tests/src/test/java/tests/dashboard/DashboardAccessTests.java
@@ -1,0 +1,28 @@
+package tests.dashboard;
+
+import helpers.ResponseVerifier;
+import io.qameta.allure.Epic;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tests.BaseTest;
+import wrappers.Dashboard;
+
+@Epic("API Tests")
+@DisplayName("[SS-T66] ACC Auth — Доступ к Dashboard без логина")
+public class DashboardAccessTests extends BaseTest {
+
+    @Test
+    @DisplayName("GET /api/stats без авторизации → 401/403")
+    void stats_unauthorized() {
+        Response r = Dashboard.getStats();
+        ResponseVerifier.verifyUnauthorized(r);
+    }
+
+    @Test
+    @DisplayName("GET /api/recent-activity без авторизации → 401/403")
+    void recent_unauthorized() {
+        Response r = Dashboard.getRecentActivity();
+        ResponseVerifier.verifyUnauthorized(r);
+    }
+}

--- a/api-tests/src/test/java/wrappers/Auth.java
+++ b/api-tests/src/test/java/wrappers/Auth.java
@@ -9,27 +9,45 @@ import io.restassured.response.Response;
 import static io.restassured.RestAssured.given;
 
 public class Auth {
+
     @Step("Send login request with {email} and {password}")
     public static Response loginUser(String email, String password) {
-
         LoginRequest loginPayload = new LoginRequest();
         loginPayload.setEmail(email);
         loginPayload.setPassword(password);
 
-        Response response =
-                given()
-                        .contentType("application/json")
-                        .body(loginPayload)
-                        .when()
-                        .post("login")
-                        .then()
-                        .assertThat()
-                        .contentType(ContentType.JSON)
-                        .extract().response();
-response.getCookie("connect.sid");
-        return response;
+        return given()
+                .contentType("application/json")
+                .body(loginPayload)
+                .when()
+                .post("login")
+                .then()
+                .assertThat()
+                .contentType(ContentType.JSON)
+                .extract().response();
     }
 
+    @Step("Get current authenticated user")
+    public static Response getCurrentUser(String cookie) {
+        return given()
+                .header("Cookie", cookie)
+                .when()
+                .get("user")
+                .then()
+                .extract().response();
+    }
+
+    @Step("Logout current session")
+    public static Response logout(String cookie) {
+        return given()
+                .header("Cookie", cookie)
+                .accept("application/json")
+                .body("")
+                .when()
+                .post("logout")
+                .then()
+                .extract().response();
+    }
 
     @Step("Verify JSON schema and status code is 200")
     public static void verifySuccessfulLoginResponse(Response response) {

--- a/api-tests/src/test/java/wrappers/Dashboard.java
+++ b/api-tests/src/test/java/wrappers/Dashboard.java
@@ -2,6 +2,7 @@ package wrappers;
 
 import io.qameta.allure.Step;
 import io.restassured.response.Response;
+
 import static io.restassured.RestAssured.given;
 
 public class Dashboard {
@@ -11,9 +12,8 @@ public class Dashboard {
         return given()
                 .header("Cookie", cookie)
                 .when()
-                .get("/stats")
+                .get("stats")
                 .then()
-                .log().all()
                 .extract().response();
     }
 
@@ -22,9 +22,26 @@ public class Dashboard {
         return given()
                 .header("Cookie", cookie)
                 .when()
-                .get("/recent-activity")
+                .get("recent-activity")
                 .then()
-                .log().all()
+                .extract().response();
+    }
+
+    @Step("Get dashboard statistics (unauthorized)")
+    public static Response getStats() {
+        return given()
+                .when()
+                .get("stats")
+                .then()
+                .extract().response();
+    }
+
+    @Step("Get recent activity (unauthorized)")
+    public static Response getRecentActivity() {
+        return given()
+                .when()
+                .get("recent-activity")
+                .then()
                 .extract().response();
     }
 }


### PR DESCRIPTION
Описание:
Добавлены API-тесты для модулей Auth и Dashboard согласно кейсам Zephyr.

Включает:
- LoginTests — SS-T30, SS-T31, SS-T32, SS-T62
- LogoutTests — SS-T69
- DashboardAccessTests — SS-T66

Примечание:
Покрыты позитивные, негативные и проверочные сценарии доступа.